### PR TITLE
Fix typo in unknown_1 register access

### DIFF
--- a/adafruit_apds9500.py
+++ b/adafruit_apds9500.py
@@ -386,7 +386,7 @@ class APDS9500:
         self.ae_gain_lb = 0x20
 
         self.manual = 0x10
-        self.unkown_1 = 0x10
+        self.unknown_1 = 0x10
         self.unknown_2 = 0x27
 
         self.apds9500_input_mode_gpio_0_1 = 0x42


### PR DESCRIPTION
This would have silently created a property on the class instance, rather than writing the register.

In a nutshell, this is why using properties in this way - while super tidy - is a bad idea. It's extremely easy to mistype a property name, and since Python will happily *create* this property instead of throwing an AttributeError you'll be none the wiser.

There must be a way to lint for this- but I couldn't find anything more graceful than `__slots__` which is tediously verbose and may have unintended side-effects.